### PR TITLE
[OPS-705] Do not depend on thrift-lib dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,23 @@
 {
 	"name": "gyg/zipper",
 	"description": "PHP convenience library to interact with Zipkin",
+	"authors": [
+		{
+			"name": "Ralph Schwaninger",
+			"email": "ralph@getyourguide.com"
+		}
+	],
 	"autoload": {
 		"psr-0": { "": "src/" },
 		"classmap": ["src/gen-php/"]
-	},
+	},	
 	"repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/getyourguide/thrift-lib"
-        }
+		{
+			"type": "composer",
+			"url": "https://toran.gygadmin.com/repo/private/"
+		}
     	],
 	"require": {
-	    "gyg/thrift-lib": "dev-master"
+	    "gyg/thrift-lib": "1.0.0"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,7 @@
 	"autoload": {
 		"psr-0": { "": "src/" },
 		"classmap": ["src/gen-php/"]
-	},	
-	"repositories": [
-		{
-			"type": "composer",
-			"url": "https://toran.gygadmin.com/repo/private/"
-		}
-    	],
+	},
 	"require": {
 	    "gyg/thrift-lib": "1.0.0"
 	}


### PR DESCRIPTION
@ralphiech as discussed before, zipper does not need to depend on thrift-lib master